### PR TITLE
Adding local-dev as a environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+.authentication-api
+.frontend
+.user-signup-api
+.logging-api
 .backend
-.frontend/
-.logging-api/
-.authentication-api/
 acceptance_tests/.certs
 fake-s3/.certs
 fake-s3/*.pem

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-setup: .frontend .authentication-api .logging-api
+setup: .frontend .authentication-api .logging-api .user-signup-api
 
-build: 
+build:
 	docker compose down
 	docker compose build --progress plain
 	docker compose up govwifi-frontend-raddb-local
@@ -12,16 +12,32 @@ test: setup build
 test-ci: build
 	docker compose run --rm govwifi-test
 
+# Assumes build has been run previously. Used for local development within this environment.
+.PHONY: local-dev
+local-dev:
+	docker compose up -d local-dev
+
+.PHONY: shell
+shell: local-dev
+	docker compose exec local-dev /bin/sh
+
+.PHONY: tail-logs
+tail-logs:
+	docker compose logs -f
+
 .frontend:
 	git clone https://github.com/GovWifi/govwifi-frontend.git .frontend
 
 .authentication-api:
 	git clone https://github.com/GovWifi/govwifi-authentication-api.git .authentication-api
 
+.user-signup-api:
+	git clone https://github.com/GovWifi/govwifi-user-signup-api.git .user-signup-api
+
 .logging-api:
 	git clone https://github.com/GovWifi/govwifi-logging-api.git .logging-api
 
-destroy: 
+destroy:
 	docker compose down --volumes
 
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,5 +140,33 @@ services:
       CERT_STORE_BUCKET: s3://certs-bucket
       ENDPOINT_URL: "http://govwifi-fake-s3:4566"
 
+  local-dev:
+    build:
+      context: local-dev
+    depends_on:
+      govwifi-logging-api-local:
+        condition: service_healthy
+      govwifi-authentication-api-local:
+        condition: service_healthy
+      govwifi-frontend-local:
+        condition: service_healthy
+    entrypoint: '/bin/sh -c ''while true ; do sleep 10 ; echo "sleeping..." ; done'''
+    environment:
+      DB_HOSTNAME: govwifi-sessions-db
+      DB_NAME: govwifi_local
+      DB_USER: root
+      DB_PASS: testpassword
+      USER_DB_NAME: govwifi_local
+      USER_DB_PASS: testpassword
+      USER_DB_USER: root
+      USER_DB_HOSTNAME: govwifi-user-details-db
+      FRONTEND_CONTAINER: govwifi-frontend-local
+      RADIUS_KEY: testingradiussecret
+      AWS_DEFAULT_REGION: eu-west-1
+      AWS_ACCESS_KEY_ID: testkey
+      AWS_SECRET_ACCESS_KEY: testsecret
+      CERT_STORE_BUCKET: s3://certs-bucket
+      ENDPOINT_URL: "http://govwifi-fake-s3:4566"
+
 volumes:
   raddb-certs:

--- a/local-dev/.dockerignore
+++ b/local-dev/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/local-dev/Dockerfile
+++ b/local-dev/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+
+WORKDIR /usr/src/app
+
+RUN apk --no-cache add --virtual .build-deps build-base && \
+    apk --no-cache add mysql-dev curl ruby mysql-client jq \
+    freeradius freeradius-radclient && \
+    apk del .build-deps
+
+COPY . .
+
+ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Adding local-dev as a environment you can make curl/radtest and generally poke around with freeradius, authentication api and logging api locally in a safe environment

---

### What
Describe the change

### Why
Describe why the change was necessary

### Link to JIRA card (if applicable): 
[GW-xxx](https://technologyprogramme.atlassian.net/browse/GW-xxx)